### PR TITLE
feat: add readme-generator skill and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Some of these are fresh ideas in beta-brainstorm mode, others are daily-use vete
 > 🦄 This project sits somewhere between “I might be onto something” and “what if I made it do *this* too?”
 > It only exists because a couple brilliant people let me ramble about it endlessly and encouraged the madness anyway.
 
+### Giorgi 📖
+
+[@georgekobaidze](https://github.com/georgekobaidze) wrote [“15 Essential Sections Every README Needs”](https://dev.to/georgekobaidze/15-essential-sections-every-readme-needs-give-your-project-what-it-deserves-fie) — the article that became the backbone of the `readme-generator` skill. Solid structure, clear rationale, zero fluff. The skill wouldn't exist without it.
+
 ### Courtney 🕹️
 
 For fearlessly testing from day one, breaking *everything* (with love), and still telling others about it. Your feedback and curiosity shaped so much of this — thank you for jumping into the chaos and making it fun.
@@ -115,6 +119,7 @@ Skills are small, reusable playbooks you can hand to an agent when you want cons
 | [`generate-commit-message`](./skills/generate-commit-message/SKILL.md) | [![Status: Check (blue badge)](https://img.shields.io/badge/status-check-3A86FF.svg)](./docs/skills/generate-commit-message-docs.md) | Generate a single Conventional Commit message from diff evidence | Deterministic formatting, no git history mutation, AI attribution included. |
 | [`eslint-plugin-configuring`](./skills/eslint-plugin-configuring/SKILL.md) | [![Status: Draft (pink badge)](https://img.shields.io/badge/status-draft-F72585.svg)](./docs/skills/eslint-plugin-configuring-docs.md) | Generate or update ESLint plugins with dual config support (v8 legacy and v9 flat) | I needed to throw one together anyway, so why not do this first? |
 | [`test-writer`](./skills/test-writer/SKILL.md) | [![Status: Ready (green badge)](https://img.shields.io/badge/status-ready-007F5F.svg)](./docs/skills/test-writer-docs.md) | Write, extend, or audit tests in any language, any framework, any repo | No `.skip`, no lowered thresholds, no copy-paste bodies. Every path, every time. |
+| [`readme-generator`](./skills/readme-generator/SKILL.md) | [![Status: Ready (green badge)](https://img.shields.io/badge/status-ready-007F5F.svg)](./docs/skills/readme-generator-docs.md) | Generate, audit, or improve a project README following a 15-section structure with Mermaid diagrams | Intent-driven section selection. No generic filler. No badge decoration. |
 
 > ⭐️ If one of these guys helped you, leave a star!
 > If it failed spectacularly, tell me. Either way, I’ll learn something — and so will the bot.

--- a/docs/skills/readme-generator-docs.md
+++ b/docs/skills/readme-generator-docs.md
@@ -1,0 +1,138 @@
+# README Generator Skill 📄
+
+![Status: Ready (green badge)](https://img.shields.io/badge/status-ready-007F5F.svg)
+
+Generate, audit, or improve a project README following a 15-section structure — with Mermaid diagrams, intent-driven section selection, and a badge discipline that won't embarrass you.
+
+Skill source: [`skills/readme-generator/SKILL.md`](../../skills/readme-generator/SKILL.md)
+
+> 📖 **Why this exists:** a README is a project's front door. Most of them leave visitors standing on the porch wondering if anyone's home. This skill follows the 15-section structure from [George Kobaidze's "15 Essential Sections Every README Needs"](https://dev.to/georgekobaidze/15-essential-sections-every-readme-needs-give-your-project-what-it-deserves-fie) (dev.to, 2025), with two opinionated additions: Mermaid for diagrams, and intent-driven section selection instead of a checklist.
+
+---
+
+## When It Triggers 🎯
+
+Any of these phrases kick it off:
+
+- `write a README`, `create a README`, `draft a README`, `generate README.md`
+- `scaffold project docs`, `document this repo`
+- `improve my README`, `audit my README`, `what should go in my README`
+- `the README is bare`, `this project has no docs`, `fill in my README sections`
+- Any request that produces or reviews a top-level repository README
+
+---
+
+## What It Does 🛠️
+
+Three distinct modes depending on what you asked for.
+
+**Fresh README:**
+
+1. Gathers context — project name, purpose, type, tech stack (pulls from `package.json`, `pyproject.toml`, `Cargo.toml`, directory listing before asking)
+2. Identifies which of the 15 sections apply based on project type
+3. Generates from `assets/template.md`; marks gaps with `<!-- TODO: ... -->` rather than fabricating content
+4. Picks the right Mermaid diagram type from `references/mermaid-guide.md`
+5. Surfaces gaps before calling it done
+
+**Existing README improvement:**
+
+1. Maps current content to the 15-section structure
+2. Lists missing or weak sections — surfaces gaps before touching anything
+3. Makes targeted improvements; preserves the user's specific phrasing where it works
+
+**Audit only:**
+
+Scores each of the 15 sections: present (✓), partial (\~), or missing (✗). One concrete improvement suggestion per gap. No rewrite unless asked.
+
+---
+
+## The 15 Sections 📋
+
+| # | Section | Purpose |
+| - | - | - |
+| 1 | Title & Introduction | Project name, one-to-two sentence pitch, small curated badge set |
+| 2 | Table of Contents | Linked anchors; skip for short READMEs |
+| 3 | About | What it is, what problem it solves, who it's for — high-level only |
+| 4 | Features | Major capabilities; *what*, not *how* |
+| 5 | Tech Stack | Languages, frameworks, runtimes, key services |
+| 6 | Architecture | Bird's-eye component view — **Mermaid diagram required** |
+| 7 | Project Structure | Annotated directory tree |
+| 8 | Getting Started | Clone, install, run — tested steps only |
+| 9 | Configuration | Env vars, config files, feature flags, valid values |
+| 10 | Security | Auth model, secrets handling, things contributors must not break |
+| 11 | How to Contribute | Branching, PR conventions, CoC link |
+| 12 | What's Next | Live roadmap items; skip if stale |
+| 13 | License | License name + plain-English summary of what readers can/can't do |
+| 14 | Acknowledgements | Contributors, libraries, inspirations |
+| 15 | Author | Who you are, how to reach you |
+
+These are a menu, not a mandate. The skill matches section selection to project type before generating:
+
+| Project type | Always include | Usually skip |
+| - | - | - |
+| Public open-source | All 15 | — |
+| Internal team service | Title, About, Tech Stack, Architecture, Getting Started, Configuration, Security, Author | Acknowledgements, What's Next |
+| CLI tool / library | Title, About, Features, Tech Stack, Getting Started, Configuration, How to Contribute, License, Author | Architecture, Project Structure |
+| Solo experiment | Title, About, Getting Started | Most others |
+| Docs / tutorial repo | Title, About, ToC, Project Structure, License, Author | Getting Started, Configuration, Security |
+
+If project type is unclear, the skill asks before generating.
+
+---
+
+## Mermaid Diagrams 🗺️
+
+Default for every diagram this skill produces. Why:
+
+- Renders natively on GitHub, GitLab, Bitbucket Cloud, Gitea, and most modern Markdown viewers
+- Plain text in version control — diff-able, reviewable in PRs
+- No external image hosting, no broken links if someone moves the assets folder
+
+Diagram-type selection (flowchart vs. sequence vs. C4 vs. ER) lives in `references/mermaid-guide.md`. Ready-to-adapt patterns are in `assets/mermaid-examples.md`. Default is `flowchart` for typical service architectures.
+
+If the rendering target doesn't support Mermaid (npm/PyPI registries are the main holdouts), the skill generates the Mermaid source and tells you to render it to SVG/PNG once and check the image in.
+
+---
+
+## Badge Discipline 🎖️
+
+Badges are load-bearing signals, not decoration. Hard rules:
+
+- **Default to zero** — add only when there's a concrete reason; License is the only near-universal one
+- **Cap at \~3, soft-cap at 5** — six badges trains readers to skip them
+- **Never restate the Tech Stack section** — "Built with React" belongs in the Tech Stack table, not the header
+- **Verify before adding** — a badge is a claim; unverifiable claims don't ship
+- **Render horizontally** — one line, space-separated; never one per line
+
+Live-count badges (stars, forks, downloads, coverage, issues) get skipped unless the number is non-embarrassing:
+
+| Badge | Skip if... |
+| - | - |
+| Stars | < \~50 stars |
+| Forks | < \~10 forks |
+| Contributors | solo project or < \~3 contributors |
+| Downloads / installs | unpublished or low traffic |
+| Open issues / PRs | brand-new repo with no triage history |
+| Coverage % | no published coverage report URL |
+| Build status | no public CI workflow at that path |
+
+A "0 stars" badge actively hurts the project. A 404-ing CI badge is worse than no badge.
+
+---
+
+## Failure Modes It Avoids ⛔
+
+- **Generic filler** — "powerful and modern application leveraging cutting-edge technologies" lands a placeholder, not that sentence
+- **Implementation details in About/Features** — stays high-level until the reader earns the depth
+- **Untested Getting Started** — unverified steps get marked; the skill won't claim they work
+- **Stale What's Next** — if the user can't say what's actually next, the section gets skipped
+- **Architecture diagrams that restate the tech stack** — if all it can draw is "Frontend → Backend → Database", it skips the diagram
+
+---
+
+## Practical Notes 🧰
+
+- Template lives at `assets/template.md` — all 15 sections pre-wired with Mermaid Architecture placeholder
+- Sections separated by horizontal rules (`---`) for scannable rendered Markdown
+- User's specific phrasing is preserved over generic rewrites when improving an existing README
+- If asking for fresh content, the skill gathers from the repo before prompting the user

--- a/skills/readme-generator/SKILL.md
+++ b/skills/readme-generator/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: readme-generator
+description: Generate, audit, or improve a project README following a 15-section structure (Title, Table of Contents, About, Features, Tech Stack, Architecture, Project Structure, Getting Started, Configuration, Security, How to Contribute, What's Next, License, Acknowledgements, Author) with Mermaid diagrams for architecture and flows. Use this skill whenever the user asks to "write a README", "create a README", "draft a README", "generate README.md", "scaffold project docs", "document this repo", "improve my README", "audit my README", "what should go in my README", or starts a new repository and needs documentation. Also trigger on phrases like "the README is bare", "this project has no docs", "fill in my README sections", or any request that produces or reviews a top-level repository README. The skill defaults to Mermaid for diagrams because it renders natively on GitHub, GitLab, Bitbucket, and most modern Markdown viewers — no external image hosting required.
+---
+
+# README Generator
+
+A README is a project's front door. The goal of this skill is to help produce a README that is structured, scannable, useful to a stranger reading it for the first time, and useful to the author six months later.
+
+This skill follows the 15-section structure from George Kobaidze's "15 Essential Sections Every README Needs" (dev.to, 2025), adapted with two opinionated choices:
+
+1. **Mermaid for diagrams**, not draw\.io / Lucidchart screenshots. Mermaid renders natively in GitHub/GitLab Markdown, lives in version control alongside the code, and is easy to update.
+2. **Section selection is intent-driven, not checklist-driven**. A "hello world" demo doesn't need an Architecture diagram. A new private monorepo probably doesn't need an Acknowledgements section. Use judgment.
+
+## When to use which sections
+
+The 15 sections are a menu, not a mandate. Default to including all of them for a non-trivial project intended for collaborators or public consumption. Trim aggressively for solo experiments or private tooling.
+
+| Project type | Always include | Usually skip |
+| - | - | - |
+| Public open-source (apps, libraries) | All 15 | — |
+| Internal team service | Title, About, Tech Stack, Architecture, Getting Started, Configuration, Security, Author | Acknowledgements, What's Next (use the issue tracker) |
+| CLI tool / library | Title, About, Features, Tech Stack, Getting Started, Configuration, How to Contribute, License, Author | Architecture, Project Structure |
+| Solo experiment / sandbox | Title, About, Getting Started | Most others |
+| Documentation-only / tutorial repo | Title, About, Table of Contents, Project Structure, License, Author | Getting Started, Configuration, Security |
+
+If the user hasn't told you which type of project this is, **ask** before generating. A wrong-shape README wastes both their time and yours.
+
+## The 15 sections
+
+For deep guidance on each section — what to include, what to leave out, common mistakes — read `references/sections.md`. The summary below is enough to draft from when the user has given clear input.
+
+1. **Title and Introduction** — Project name as `# H1`. One- or two-sentence pitch. Optional: logo, screenshot, demo link, and a *small* set of badges (see "Badges" below — never a long list).
+2. **Table of Contents** — Linked anchors to each section. Skip for very short READMEs (under \~5 sections).
+3. **About** — What the project is, what problem it solves, who it's for. High-level only. No implementation details.
+4. **Features** — Major capabilities. Either a feature/description table or a subheading per feature with more detail. Stay at the *what*, not the *how*.
+5. **Tech Stack** — Languages, frameworks, runtimes, key libraries, infra, third-party services. A simple bulleted list or a categorized table both work.
+6. **Architecture** — Bird's-eye view of how the components fit together. **Use a Mermaid diagram.** See `references/mermaid-guide.md` for which diagram type to pick.
+7. **Project Structure** — Annotated directory tree. Tedious to write, valuable for onboarding and for future-you.
+8. **Getting Started** — How a new developer clones, installs, and runs the project locally. Test these steps yourself; missing details here are the #1 reason contributors bounce.
+9. **Configuration** — Environment variables, config files, feature flags, external service credentials. Document what each setting does and what valid values look like.
+10. **Security** — Key security considerations: auth model, secrets handling, threat model basics, things contributors must not break. Link to a `SECURITY.md` for a full disclosure policy if you have one.
+11. **How to Contribute** — Branching/PR conventions, commit style, code-of-conduct link, where to ask questions. Keep simple for new projects.
+12. **What's Next** — Roadmap items. Signals the project is alive and gives contributors hooks to grab.
+13. **License** — License name (linked to LICENSE) **plus** a one- or two-sentence plain-English summary of what readers can and can't do. The bare "Licensed under X — see LICENSE for details" line is dead weight; the link already says that. Default assumption for this user's repos: **non-standard / source-available** (Polyform Shield, BSL, SSPL, FSL) — readers will pattern-match "GitHub repo" → "MIT-shaped permissions" unless the prose says otherwise. Match the changelog-writer voice (cheeky, dry, narrative) — see `references/sections.md` for required structure and example copy. Don't paste the full license text.
+14. **Acknowledgements** — Contributors, libraries, inspirations, prior art.
+15. **Author** — Who you are, how to reach you, links to portfolio / socials. Last but not least.
+
+Separate sections with horizontal rules (`---`) to make them visually distinct on rendered Markdown.
+
+## How to draft
+
+The flow depends on what the user has given you.
+
+### If the user is asking for a fresh README
+
+1. **Gather context first.** You need at minimum: project name, one-sentence purpose, project type (from the table above), and primary tech stack. If the repo is accessible (file paths shared, or you can search it), pull what you can — `package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`, top-level directory listing — before asking the user.
+2. **Identify what's missing.** Don't fabricate. If you don't know how to install the project, the Getting Started section needs the user's input, not your guess.
+3. **Generate the draft.** Start from `assets/template.md`. Fill in every section you have signal for. For sections you can't responsibly fill, leave a clearly marked placeholder like `<!-- TODO: describe X -->` rather than inventing content.
+4. **Pick the right Mermaid diagram for Architecture.** See `references/mermaid-guide.md`. Default to a `flowchart` for typical service architectures.
+5. **Show the user the draft and call out gaps.** Don't pretend the README is complete when half of it is placeholders.
+
+### If the user has an existing README and wants it improved
+
+1. **Read what they have.** Map their existing content to the 15-section structure. Some sections may be present under different names ("Setup" instead of "Getting Started", "Stack" instead of "Tech Stack") — preserve the user's terminology if it's reasonable.
+2. **List what's missing or weak** before rewriting. Don't silently restructure — surface the gaps so they can decide.
+3. **Make targeted improvements.** Don't replace working content with generic boilerplate. The user's specific phrasing usually beats your generic version.
+
+### If the user wants an audit only (no rewrite)
+
+Score the README against the 15 sections. For each section: present (✓), partial (\~), or missing (✗). For partial/missing, suggest one concrete improvement. Don't generate replacement content unless asked.
+
+## Mermaid diagrams
+
+Mermaid is the default for any diagram this skill produces. Why:
+
+- Renders natively on GitHub, GitLab, Bitbucket Cloud, Gitea, and most modern Markdown viewers
+- Lives as plain text in version control
+- Diff-able and reviewable in pull requests
+- No external image hosting, no broken links when someone moves the assets folder
+
+For diagram-type selection (flowchart vs. sequence vs. C4 vs. ER, etc.), see `references/mermaid-guide.md`. For ready-to-adapt patterns, see `assets/mermaid-examples.md`.
+
+If the rendering target doesn't support Mermaid (rare — npm and PyPI registries are the main holdouts), generate the Mermaid source anyway and tell the user to render it to SVG/PNG once and check the image into the repo.
+
+## The template
+
+`assets/template.md` is a fill-in-the-blanks version of all 15 sections with horizontal rules between them and a Mermaid example pre-wired into the Architecture section. Start from there for new READMEs.
+
+## Badges
+
+Badges are **load-bearing signals**, not decoration. Every badge must earn its row by communicating something the reader can't get faster from the prose underneath. A long stack of badges trains readers to skip them entirely — and dilutes the ones that actually matter.
+
+### Hard rules
+
+- **Default to zero.** Add badges only when there's a concrete reason. License is the only one that's almost always worth it on a public repo.
+- **Cap at \~3, soft-cap at 5.** If you find yourself reaching for a 6th badge, you're decorating.
+- **Never use a badge to restate the Tech Stack section.** "Built with React" / "Uses TypeScript" / "Powered by Postgres" tell the reader something they'll learn in the next paragraph. The Tech Stack table does this better.
+- **Verify before adding.** A badge is a claim. If you can't verify the claim from repo state, do not add it.
+- **Render horizontally.** Put all badges on a single line separated by spaces — never one per line. Markdown line breaks force vertical stacking, which looks like a checklist instead of a header. Use newlines only when grouping makes sense (e.g., a row of "status" badges above a row of "package metadata" badges) — not as default formatting.
+
+### Skip when the number would embarrass you
+
+Some badges render a live count. Never add them unless the count is non-trivial *today*:
+
+| Badge | Skip if… |
+| - | - |
+| Stars | repo has < \~50 stars (or you can't check) |
+| Forks | < \~10 forks |
+| Contributors | solo project, or < \~3 contributors |
+| Downloads / installs | unpublished package, or low/zero traffic |
+| Open issues / PRs | brand-new repo with no triage history |
+| Coverage % | no published coverage report URL |
+| Build status | no public CI workflow at that path |
+
+A "0 stars" badge actively hurts the project. A missing CI badge that 404s looks worse than no badge at all.
+
+### What's usually worth it
+
+For a typical open-source project, the strongest badges are:
+
+- **License** — legal signal, always relevant
+- **CI status** — only if the workflow exists and runs on `main`
+- **Security scan status** (CodeQL, Snyk, etc.) — only if wired up
+- **Latest release / version** — only for published packages where the version moves
+- **Conventional Commits** — only if commitlint is actually enforced (otherwise it's a lie)
+
+Everything else (logo-only "built with X" badges, framework badges, runtime version badges) belongs in the Tech Stack section, not the title.
+
+### Workflow
+
+1. List the candidate badges you're tempted to add.
+2. For each, ask: *what does this tell the reader that the rest of the README doesn't?*
+3. For each live-count badge, verify the count is non-embarrassing.
+4. For each link target, verify the URL resolves.
+5. Trim ruthlessly. Three good badges beat ten weak ones.
+
+## Common failure modes to avoid
+
+- **Generic filler.** "This is a powerful and modern application that leverages cutting-edge technologies" tells the reader nothing. If you don't have specifics, leave a placeholder.
+- **Implementation details in About/Features.** The reader hasn't earned that detail yet. Keep those sections high-level.
+- **Untested Getting Started.** If the user hasn't run the steps themselves, mark the section as needing verification. Don't claim it works.
+- **Stale What's Next.** A "coming soon" list from two years ago is worse than no list. If the user can't say what's actually next, skip the section.
+- **Diagrams that just restate the tech stack.** An architecture diagram should show *interactions* between components, not just box-list them. If all you can draw is "Frontend → Backend → Database", that's a sign the system is too simple to need a diagram.

--- a/skills/readme-generator/assets/mermaid-examples.md
+++ b/skills/readme-generator/assets/mermaid-examples.md
@@ -1,0 +1,180 @@
+# Mermaid examples for README diagrams
+
+Pick the diagram type that matches what you're trying to communicate. The patterns below are starting points — adapt names, arrows, and styling to the project.
+
+## 1. Web app architecture (flowchart)
+
+Use when showing how a typical web/service architecture fits together.
+
+```mermaid
+flowchart LR
+    User([User])
+    CDN[CDN / Edge]
+    Web[Web App<br/>Next.js]
+    API[API Server<br/>Node.js]
+    DB[(PostgreSQL)]
+    Cache[(Redis)]
+    Queue[Background Worker]
+    External[Third-party API]
+
+    User --> CDN --> Web
+    Web --> API
+    API --> DB
+    API --> Cache
+    API --> Queue
+    Queue --> External
+    Queue --> DB
+```
+
+## 2. Microservices / event-driven (flowchart with subgraphs)
+
+Use when components group naturally into bounded contexts.
+
+```mermaid
+flowchart TB
+    User([User])
+
+    subgraph Edge
+        LB[Load Balancer]
+        Gateway[API Gateway]
+    end
+
+    subgraph Services
+        Auth[Auth Service]
+        Orders[Orders Service]
+        Inventory[Inventory Service]
+    end
+
+    subgraph Data
+        OrdersDB[(Orders DB)]
+        InventoryDB[(Inventory DB)]
+        Bus[[Event Bus]]
+    end
+
+    User --> LB --> Gateway
+    Gateway --> Auth
+    Gateway --> Orders
+    Gateway --> Inventory
+    Orders --> OrdersDB
+    Inventory --> InventoryDB
+    Orders --> Bus
+    Inventory --> Bus
+    Bus --> Orders
+    Bus --> Inventory
+```
+
+## 3. Request lifecycle (sequence diagram)
+
+Use when the *order of operations* matters more than the components.
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant W as Web App
+    participant A as API
+    participant D as Database
+    participant Q as Queue
+
+    U->>W: Click "Submit Order"
+    W->>A: POST /orders
+    A->>D: INSERT order (pending)
+    A->>Q: enqueue ProcessOrder
+    A-->>W: 202 Accepted
+    W-->>U: "Order received"
+    Q->>D: UPDATE order (confirmed)
+    Q->>U: Email confirmation
+```
+
+## 4. State machine (stateDiagram)
+
+Use when the project's core entity has a non-trivial lifecycle.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Draft
+    Draft --> Submitted: submit()
+    Submitted --> Approved: approve()
+    Submitted --> Rejected: reject()
+    Approved --> Published: publish()
+    Rejected --> Draft: revise()
+    Published --> Archived: archive()
+    Archived --> [*]
+```
+
+## 5. Data model (ER diagram)
+
+Use for libraries or apps where the schema is the story.
+
+```mermaid
+erDiagram
+    USER ||--o{ ORDER : places
+    ORDER ||--|{ LINE_ITEM : contains
+    PRODUCT ||--o{ LINE_ITEM : "appears in"
+
+    USER {
+        uuid id PK
+        string email
+        string name
+        timestamp created_at
+    }
+    ORDER {
+        uuid id PK
+        uuid user_id FK
+        string status
+        timestamp created_at
+    }
+    LINE_ITEM {
+        uuid id PK
+        uuid order_id FK
+        uuid product_id FK
+        int quantity
+        decimal unit_price
+    }
+    PRODUCT {
+        uuid id PK
+        string sku
+        string name
+        decimal price
+    }
+```
+
+## 6. CLI / library data flow (flowchart, simpler)
+
+Use for CLI tools, libraries, or build pipelines.
+
+```mermaid
+flowchart LR
+    Input[Input file] --> Parser
+    Parser --> AST[(AST)]
+    AST --> Transform
+    Transform --> Renderer
+    Renderer --> Output[Output file]
+
+    Config[Config file] -.-> Parser
+    Config -.-> Transform
+    Config -.-> Renderer
+```
+
+## 7. CI/CD pipeline (flowchart top-to-bottom)
+
+Use when documenting how code gets to production.
+
+```mermaid
+flowchart TB
+    Push([Push to main]) --> Lint
+    Lint --> Test[Unit tests]
+    Test --> Build[Build artifact]
+    Build --> Stage[Deploy to staging]
+    Stage --> E2E[E2E tests]
+    E2E --> Approve{Manual approval}
+    Approve -->|approved| Prod[Deploy to production]
+    Approve -->|rejected| Rollback[Stop]
+```
+
+## Styling tips
+
+- Keep the diagram **small enough to read on a phone** — if it sprawls, split it into two diagrams.
+- Use `[(Database shape)]` for data stores, `([Round shape])` for actors/users, `[[Subroutine shape]]` for queues/buses, plain `[Rectangle]` for services.
+- Prefer `LR` (left-to-right) for request flows, `TB` (top-to-bottom) for pipelines and hierarchies.
+- Don't show every component. The diagram should highlight the parts a reader needs to understand the system; details belong in deeper docs.
+- If one path is the "happy path," draw it with solid arrows and put failure / async paths in dotted (`-.->`).

--- a/skills/readme-generator/assets/template.md
+++ b/skills/readme-generator/assets/template.md
@@ -1,0 +1,237 @@
+# {{Project Name}}
+
+> {{One-sentence pitch: what this project does and who it's for.}}
+
+<!-- Optional: badges, logo, hero screenshot, demo link.
+     Examples:
+     ![License](https://img.shields.io/github/license/{owner}/{repo})
+     ![Build](https://img.shields.io/github/actions/workflow/status/{owner}/{repo}/ci.yml)
+     [Live demo]({{demo-url}}) · [Documentation]({{docs-url}})
+-->
+
+---
+
+## Table of Contents
+
+- [About](#about)
+- [Features](#features)
+- [Tech Stack](#tech-stack)
+- [Architecture](#architecture)
+- [Project Structure](#project-structure)
+- [Getting Started](#getting-started)
+- [Configuration](#configuration)
+- [Security](#security)
+- [How to Contribute](#how-to-contribute)
+- [What's Next](#whats-next)
+- [License](#license)
+- [Acknowledgements](#acknowledgements)
+- [Author](#author)
+
+---
+
+## About
+
+{{Two or three short paragraphs: what the project is, what problem it solves, who it's for, and at a high level how it works. No implementation details — those come later.}}
+
+---
+
+## Features
+
+{{Pick one of the two layouts below. Delete the other.}}
+
+**Table layout (best for \~3-7 features):**
+
+| Feature | Description |
+| - | - |
+| {{Feature 1}} | {{One-line description}} |
+| {{Feature 2}} | {{One-line description}} |
+| {{Feature 3}} | {{One-line description}} |
+
+**Subheading layout (best when each feature needs more explanation):**
+
+### {{Feature 1}}
+
+{{1-2 sentences. Stay at the level of *what it does*, not *how it works*.}}
+
+### {{Feature 2}}
+
+{{1-2 sentences.}}
+
+---
+
+## Tech Stack
+
+- **Language:** {{e.g., TypeScript 5.x, Python 3.12, Go 1.22}}
+- **Framework:** {{e.g., Next.js 14, FastAPI, Gin}}
+- **Database:** {{e.g., PostgreSQL 16, SQLite, Redis}}
+- **Infra:** {{e.g., Docker, AWS ECS, Cloudflare Workers}}
+- **Notable libraries:** {{e.g., Drizzle ORM, Pydantic, Zod}}
+- **Tooling:** {{e.g., pnpm, ruff, golangci-lint}}
+
+---
+
+## Architecture
+
+{{Replace this Mermaid diagram with one that reflects your actual system. See `mermaid-examples.md` in this skill for more patterns.}}
+
+```mermaid
+flowchart LR
+    User([User])
+    Web[Web App<br/>Next.js]
+    API[API<br/>FastAPI]
+    DB[(PostgreSQL)]
+    Cache[(Redis)]
+    Queue[Background Worker]
+
+    User --> Web
+    Web --> API
+    API --> DB
+    API --> Cache
+    API --> Queue
+    Queue --> DB
+```
+
+{{One short paragraph describing the flow: what each component does, how requests move through the system, where state lives. Keep it to what the diagram doesn't already show.}}
+
+---
+
+## Project Structure
+
+```
+{{project-name}}/
+├── src/                  # Application source code
+│   ├── api/              # HTTP handlers and routing
+│   ├── domain/           # Business logic, types, entities
+│   ├── infra/            # External integrations (DB, queue, third-party APIs)
+│   └── ui/               # Frontend components and pages
+├── tests/                # Unit and integration tests
+├── scripts/              # Dev/CI/deployment scripts
+├── docs/                 # Extended documentation
+├── .env.example          # Template for required environment variables
+├── docker-compose.yml    # Local dev stack
+└── README.md
+```
+
+---
+
+## Getting Started
+
+### Prerequisites
+
+- {{e.g., Node.js 20+}}
+- {{e.g., Docker and Docker Compose}}
+- {{e.g., A `.env` file (copy from `.env.example`)}}
+
+### Install
+
+```bash
+git clone https://github.com/{{owner}}/{{repo}}.git
+cd {{repo}}
+{{install command, e.g., pnpm install}}
+```
+
+### Run locally
+
+```bash
+cp .env.example .env
+{{any required setup, e.g., docker compose up -d postgres}}
+{{run command, e.g., pnpm dev}}
+```
+
+The app should be available at `http://localhost:{{port}}`.
+
+### Run the tests
+
+```bash
+{{e.g., pnpm test}}
+```
+
+> **Verify these steps yourself before publishing.** Missing one detail here is the most common reason a contributor gives up.
+
+---
+
+## Configuration
+
+| Variable | Required | Default | Description |
+| - | - | - | - |
+| `DATABASE_URL` | yes | — | Postgres connection string |
+| `REDIS_URL` | yes | — | Redis connection string |
+| `LOG_LEVEL` | no | `info` | One of `debug`, `info`, `warn`, `error` |
+| `PORT` | no | `3000` | HTTP port the server binds to |
+| `{{ANOTHER_VAR}}` | {{yes/no}} | {{default}} | {{description}} |
+
+See `.env.example` for the canonical list.
+
+---
+
+## Security
+
+- **Secrets:** never commit `.env`. Production secrets live in {{your secret manager}}.
+- **Auth model:** {{e.g., session cookies issued by API, validated on every request}}.
+- **Threat model:** {{a sentence or two about what you're defending against and what's out of scope}}.
+- **Reporting vulnerabilities:** see `SECURITY.md`, or email {{security-contact}}.
+
+When adding new features, follow the existing patterns for input validation, authorization checks, and secret handling. Don't bypass them "temporarily."
+
+---
+
+## How to Contribute
+
+1. Fork the repo and create a feature branch from `main`.
+2. Run the test suite locally and make sure it passes.
+3. Open a pull request describing the change. Reference the issue it closes if applicable.
+4. A maintainer will review within {{timeframe}}.
+
+Commit messages follow {{convention, e.g., Conventional Commits}}. Code style is enforced by {{linter}}; run `{{lint command}}` before pushing.
+
+For bigger changes, open an issue first to discuss the approach.
+
+---
+
+## What's Next
+
+Planned work, in rough priority order:
+
+- [ ] {{Upcoming feature 1}}
+- [ ] {{Upcoming feature 2}}
+- [ ] {{Tech debt item}}
+- [ ] {{Quality-of-life improvement}}
+
+Suggestions and contributions on any of these are welcome.
+
+---
+
+## License
+
+<!--
+DEFAULT for this user: Polyform Shield 1.0.0 (non-standard, source-available — NOT OSI-approved).
+Use the block below verbatim unless the user has explicitly named a different license.
+If a non-Polyform license is in play, keep the structure: name + plain-English summary of constraints.
+Never ship the bare "Licensed under X — see [LICENSE] for details" line.
+-->
+
+Released under the [Polyform Shield License 1.0.0](LICENSE). Source-available, not open-source — read the license before you build a paid SaaS on top of it.
+
+- **You can:** use it, fork it, learn from it, ship it inside your day job, hand it to a client.
+- **You can't:** sell it, rebrand it, host it as paid SaaS, or otherwise monetize it without explicit written permission.
+- **Public forks:** include the LICENSE file and credit the original work.
+
+---
+
+## Acknowledgements
+
+- {{Library or framework that did the heavy lifting}}
+- {{Person, project, or article that inspired this}}
+- {{Contributors who shaped the design}}
+
+---
+
+## Author
+
+**{{Your Name}}**
+
+- GitHub: [@{{handle}}](https://github.com/{{handle}})
+- Website: {{url}}
+- Email: {{email}}
+
+Open to questions, feedback, and collaboration.

--- a/skills/readme-generator/references/mermaid-guide.md
+++ b/skills/readme-generator/references/mermaid-guide.md
@@ -1,0 +1,106 @@
+# Mermaid diagram type selection guide
+
+Use this guide to pick the right Mermaid diagram type for the Architecture section (and anywhere else you reach for a diagram in the README).
+
+## Decision rules
+
+Ask: **what is the diagram trying to show?**
+
+| You want to show… | Use |
+| - | - |
+| Components and how data/requests flow between them | `flowchart` |
+| The sequence of messages between actors over time | `sequenceDiagram` |
+| The lifecycle of a single entity (states + transitions) | `stateDiagram-v2` |
+| The data model / database schema | `erDiagram` |
+| A pipeline (CI/CD, build, ETL) with linear-ish stages | `flowchart TB` |
+| Class hierarchies in an OO codebase | `classDiagram` |
+| User journey through a product | `journey` |
+| Project plan / Gantt chart | `gantt` |
+| Pie chart of categorical breakdown | `pie` |
+
+## Default for "Architecture"
+
+For most service-shaped projects (web app, API + workers + DB, microservices), default to **`flowchart LR`** (left-to-right). This gives you the typical "request enters from the left, traverses the system, hits the database on the right" reading order that matches how people mentally model HTTP traffic.
+
+For pipelines, builds, or anything where progress is the point, use **`flowchart TB`** (top-to-bottom).
+
+## Shapes by component type
+
+Pick shapes that match what each component *is*, not just to add visual variety.
+
+| Shape syntax | Use for |
+| - | - |
+| `[Service Name]` | Services, applications, generic boxes |
+| `([User])` | External actors, users, clients |
+| `[(Database)]` | Databases, persistent stores |
+| `[[Queue]]` | Queues, message buses, subroutines |
+| `>Note]` | Annotations, side comments |
+| `{Decision?}` | Branching logic in pipelines |
+
+## Arrow styles
+
+| Syntax | Means |
+| - | - |
+| `-->` | Synchronous call / hard dependency |
+| `-.->` | Async, optional, or fallback path |
+| `==>` | Emphasized / primary path |
+| `--x` | Failure or terminating path |
+
+Use the visual difference deliberately — e.g., the happy path in solid lines, the async/event-driven side paths in dotted.
+
+## Subgraphs (grouping)
+
+Use `subgraph` to group components by bounded context, deployment unit, or trust boundary. Don't overdo it; one to three subgraphs in a single diagram is plenty.
+
+```mermaid
+flowchart LR
+    subgraph Public
+        User([User])
+        CDN[CDN]
+    end
+
+    subgraph "Application Tier"
+        Web[Web]
+        API[API]
+    end
+
+    subgraph "Data Tier"
+        DB[(DB)]
+        Cache[(Cache)]
+    end
+
+    User --> CDN --> Web --> API --> DB
+    API --> Cache
+```
+
+## When *not* to use Mermaid
+
+Mermaid is the default but not the only option. Reach for something else when:
+
+- **The system is too complex for any single diagram.** Split into multiple smaller diagrams or use a dedicated architecture-as-code tool (Structurizr / C4, Excalidraw exports). A 60-node Mermaid graph is unreadable.
+- **The visual fidelity matters.** For published architecture posts, hand-drawn or designer-tooled diagrams may be worth the extra effort. A README typically isn't that.
+- **The render target doesn't support Mermaid.** npm registry, PyPI, and some older Markdown viewers don't render Mermaid. Solution: keep the Mermaid source in the README, render it once to SVG, and check the SVG into the repo as a fallback.
+
+## Render target compatibility
+
+Confirmed Mermaid-native rendering:
+
+- GitHub (since 2022)
+- GitLab
+- Bitbucket Cloud
+- Gitea / Forgejo
+- Most static site generators with a Mermaid plugin (Docusaurus, MkDocs, Hugo)
+- VS Code Markdown preview
+
+Does **not** render Mermaid:
+
+- npm package page
+- PyPI package page
+- Some corporate wiki tools (Confluence native — needs a plugin)
+
+## Quick troubleshooting
+
+- **Diagram appears as a literal code block on GitHub** — make sure the fence is exactly ` ```mermaid ` with no extra characters, and that it's a `.md` file (not `.txt`).
+- **Mermaid syntax error** — paste the diagram into [mermaid.live](https://mermaid.live) to get a clearer error message than GitHub gives.
+- **Long node labels overflow** — use `<br/>` to wrap manually inside a label, or shorten the label and put the full description in the prose below.
+- **Arrows crossing each other** — try changing direction (`LR` ↔ `TB`), or split into two diagrams.

--- a/skills/readme-generator/references/sections.md
+++ b/skills/readme-generator/references/sections.md
@@ -1,0 +1,212 @@
+# Section-by-section guidance
+
+Deeper notes on each of the 15 sections. Read this when drafting a section that needs care, or when auditing a README and judging whether an existing section is doing its job.
+
+## Table of contents
+
+1. [Title and Introduction](#title-and-introduction)
+2. [Table of Contents](#table-of-contents)
+3. [About](#about)
+4. [Features](#features)
+5. [Tech Stack](#tech-stack)
+6. [Architecture](#architecture)
+7. [Project Structure](#project-structure)
+8. [Getting Started](#getting-started)
+9. [Configuration](#configuration)
+10. [Security](#security)
+11. [How to Contribute](#how-to-contribute)
+12. [What's Next](#whats-next)
+13. [License](#license)
+14. [Acknowledgements](#acknowledgements)
+15. [Author](#author)
+
+---
+
+## Title and Introduction
+
+**Purpose:** capture the reader's attention in 5 seconds.
+
+**Include:** project name as `# H1`, a one- or two-sentence pitch (what it does + who it's for), and optionally: logo, badges (build status, license, version, package downloads), a screenshot or short demo GIF, links to a live demo / docs site / video walkthrough.
+
+**Avoid:** marketing fluff ("revolutionary, cutting-edge…"), implementation details, version history.
+
+**Common badge sources:** shields.io, badgen.net. Include only badges that signal something the reader cares about — a green "build passing" is useful, "100% TypeScript" usually isn't.
+
+## Table of Contents
+
+**Purpose:** orient the reader, let them jump to what they need.
+
+**Include:** linked anchors to every `##` section.
+
+**Skip when:** the README is shorter than \~5 sections. A TOC for 4 items is noise.
+
+**GitHub note:** GitHub auto-generates a TOC dropdown from the headings, so the manual TOC is partially redundant on github.com — but it still serves people reading the file in IDEs, code search results, or rendered docs sites. Keep it.
+
+## About
+
+**Purpose:** explain what the project is and why it exists, in plain language.
+
+**Include:** the problem the project solves, who the audience is, the high-level approach. Two or three short paragraphs is the sweet spot.
+
+**Avoid:** repeating the one-line pitch from the intro; jumping into implementation; writing it for an audience that already knows the project.
+
+**Test:** could a stranger tell, after reading this section alone, whether this project is relevant to them? If not, it's not doing its job.
+
+## Features
+
+**Purpose:** show what the project actually does, at a glance.
+
+**Two layouts:**
+
+- **Table** — feature name + one-line description. Best for 3-7 features.
+- **Subheadings** — `### Feature Name` followed by 1-3 sentences. Best when each feature needs context.
+
+**Stay at the *what*, not the *how*.** "Real-time collaborative editing" is a feature. "Uses WebSockets with operational transforms over a Redis-backed pub/sub" is implementation detail — that goes in Architecture or deeper docs.
+
+## Tech Stack
+
+**Purpose:** tell readers what the project is built with so they can decide if it fits their skills or stack.
+
+**Include:** language + version, framework, runtime, database, key libraries, infra/hosting, build tooling.
+
+**Format:** bulleted list with bold labels works well. A categorized table works for larger stacks.
+
+**Avoid:** listing every transitive dependency. Stick to the things that meaningfully shape the project.
+
+## Architecture
+
+**Purpose:** show how the components of the system fit together at a glance.
+
+**Default to a Mermaid diagram.** See `../assets/mermaid-examples.md` for type selection (flowchart vs. sequence vs. ER vs. state).
+
+**Include with the diagram:** one short paragraph explaining what the diagram doesn't (e.g., where state lives, what's synchronous vs. async, what's a hard dependency vs. a fallback).
+
+**Avoid:** diagrams that just restate the tech stack as boxes. The point is to show *interactions*, not *components*.
+
+**Skip when:** the system is genuinely simple (single binary, no external deps, no async). Forcing a diagram on a 200-line CLI looks ridiculous.
+
+## Project Structure
+
+**Purpose:** orient a contributor to the codebase before they start opening files.
+
+**Format:** ASCII directory tree with inline comments on each meaningful entry. Don't list every file — list the directories and the conventions.
+
+**Example shape:**
+
+```
+src/
+├── api/          # HTTP handlers; one file per resource
+├── domain/       # Business logic, no I/O
+└── infra/        # External integrations (DB, queue, third-party APIs)
+```
+
+**Avoid:** a full `tree` dump that's three pages long. Trim aggressively to the load-bearing directories.
+
+## Getting Started
+
+**Purpose:** get a new developer from `git clone` to a running app on their machine.
+
+**Include:** prerequisites (with versions), clone command, install command, environment setup (`.env` file copy), any local services to start (Docker Compose, dev databases), the run command, the URL to open, and how to run the tests.
+
+**Verify the steps yourself.** Open a fresh terminal, follow your own README, see if it works. Missing one detail here is the #1 reason contributors give up.
+
+**Common gaps to watch for:** node version mismatches, undocumented system packages, missing migrations, ports already in use, secrets that need to be requested out-of-band.
+
+## Configuration
+
+**Purpose:** document every dial a deployer or contributor might need to turn.
+
+**Format:** a table is almost always the right format. Columns: variable name, required (yes/no), default value, description. Optionally a fifth column for "valid values" if the set is discrete.
+
+**Include:** environment variables, config file paths, feature flags, external service credentials (with link to where to obtain them, not the value).
+
+**Pair with `.env.example`:** the README documents what each variable does; the `.env.example` file is the actual copy-pasteable template. Both should exist.
+
+## Security
+
+**Purpose:** make sure contributors don't accidentally introduce vulnerabilities.
+
+**Include:** auth model in one paragraph, secrets handling rules, the threat model in broad strokes (what you're defending against and what's out of scope), and a pointer to a `SECURITY.md` for the formal disclosure policy.
+
+**Avoid:** treating this as a checklist of buzzwords. "We use HTTPS" doesn't tell a contributor anything actionable. "All API routes require a valid session cookie; the validation middleware lives in `src/api/middleware/auth.ts` and runs before every handler" is actionable.
+
+**Skip when:** the project has no auth, no secrets, no user data, and no external integrations.
+
+## How to Contribute
+
+**Purpose:** lower the friction for outside contributions.
+
+**Include:** branching strategy (feature branches off `main`?), PR process, commit message conventions, code style / linting expectations, where to ask questions, and any larger-changes-need-an-issue-first norms.
+
+**Length scaling:** for a small project, 4-5 lines is plenty. For a large open-source project, link to a separate `CONTRIBUTING.md`.
+
+## What's Next
+
+**Purpose:** signal the project is alive and give contributors hooks.
+
+**Format:** a checklist of upcoming items. Roughly prioritized.
+
+**Avoid:** a stale list. A "coming soon" section from two years ago is worse than no section. If you can't update it, don't include it.
+
+**Alternative:** for projects with a real issue tracker, a sentence like "See the [open issues]({{url}}) for current priorities" is enough.
+
+## License
+
+**Purpose:** tell readers what they're allowed to do with the code — and, more importantly, what they're not.
+
+**Include:** license name (linked to the LICENSE file) **plus a one- or two-sentence plain-English summary of the actual constraints.** The summary is the load-bearing part. A bare "Licensed under X — see \[LICENSE] for details" is dead weight: the link already says that, and readers will pattern-match "repo on GitHub" → "MIT-shaped permissions" and assume things you never granted.
+
+**Don't:**
+
+- paste the full license text into the README — the LICENSE file is canonical
+- ship the dry "This project is licensed under X — see \[LICENSE] for details" line; the prose has to outwork the link
+- soften the constraints to sound friendlier — if commercial use is restricted, say so plainly
+
+**Tone:** match the rest of the README. For projects following the changelog-writer voice (cheeky, dry, narrative — see `~/.claude/skills/changelog-writer/SKILL.md`), the License section gets that same edge. It should read like a doorman, not a EULA.
+
+### Non-standard / source-available licenses — the default for this user
+
+Polyform Shield, BSL, SSPL, FSL, "custom" — anything that isn't OSI-approved. **Default assumption:** every repo this user ships uses one of these. Treat OSI licenses as the exception, not the rule, and confirm before writing one in.
+
+Required structure for non-standard licenses:
+
+1. Name the license, linked to LICENSE.
+2. State, in one short clause, that it's **not** open-source / not OSI-approved. Readers need this said out loud.
+3. Three bullets:
+   - **You can:** the everyday use cases (use, fork, internal work, client projects, education)
+   - **You can't:** the bright-line restrictions (sell, paid SaaS, rebrand, monetize) without explicit permission
+   - **Public forks:** attribution requirements, if any
+
+Example copy for Polyform Shield 1.0.0 (this user's default):
+
+> Released under the [Polyform Shield License 1.0.0](LICENSE). Source-available, not open-source — read the license before you build a paid SaaS on top of it.
+>
+> - **You can:** use it, fork it, learn from it, ship it inside your day job, hand it to a client.
+> - **You can't:** sell it, rebrand it, host it as paid SaaS, or otherwise monetize it without explicit written permission.
+> - **Public forks:** include the LICENSE file and credit the original work.
+
+### Standard OSI licenses (rare for this user)
+
+MIT, Apache-2.0, BSD, GPL — constraints are well-known, a short blurb is enough.
+
+Example: `Released under the [MIT License](LICENSE).`
+
+**Choosing a license:** if the user hasn't named one, **ask**. Do not invent a license or silently default to MIT — and do not silently default to Polyform Shield either, even though it's the usual answer. Confirm.
+
+## Acknowledgements
+
+**Purpose:** credit the people, libraries, and prior art that made the project possible.
+
+**Include:** notable open-source dependencies, contributors, design or technical inspirations, articles or talks that shaped the approach.
+
+**Skip when:** the project doesn't have meaningful external influences (a solo experiment built on the framework's defaults), or when this is private code where the audience doesn't care.
+
+## Author
+
+**Purpose:** make it easy to reach the maintainer.
+
+**Include:** name, GitHub handle, optionally website / email / social link.
+
+**For multi-author projects:** rename to "Authors" or "Maintainers" and list each.
+
+**Don't:** include a phone number or anything you'd regret being scraped.


### PR DESCRIPTION
## Summary

- Adds `skills/readme-generator/` — SKILL.md, reference docs (`sections.md`, `mermaid-guide.md`), and template assets (`template.md`, `mermaid-examples.md`)
- Adds `docs/skills/readme-generator-docs.md` following existing skill doc conventions
- Updates `README.md`: new Skills table entry and Giorgi (@georgekobaidze) shoutout crediting the source article

## Test plan

- [ ] Verify README renders correctly on GitHub (Skills table, Giorgi shoutout, badge)
- [ ] Verify `docs/skills/readme-generator-docs.md` link in Skills table resolves
- [ ] Trigger skill with "write a README" prompt and confirm 15-section structure is followed

🤖 Generated with [Claude Code](https://claude.com/claude-code)